### PR TITLE
feat: Implement issue-1 (resart app / retry API)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
+        "axios-retry": "^4.0.0",
         "crypto-js": "^4.2.0",
         "incyclist-ant-plus": "github:edabe/incyclist-ant-plus",
         "nconf": "^0.12.1",
@@ -644,6 +645,17 @@
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.0.0.tgz",
+      "integrity": "sha512-F6P4HVGITD/v4z9Lw2mIA24IabTajvpDZmKa6zq/gGwn57wN5j1P3uWrAV0+diqnW6kTM2fTqmWNfgYWGmMuiA==",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/balanced-match": {
@@ -1531,6 +1543,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "axios": "^1.6.2",
+    "axios-retry": "^4.0.0",
     "crypto-js": "^4.2.0",
     "incyclist-ant-plus": "github:edabe/incyclist-ant-plus",
     "nconf": "^0.12.1",

--- a/src/DreoAPI.ts
+++ b/src/DreoAPI.ts
@@ -1,8 +1,19 @@
 import axios from 'axios';
+import axiosRetry from 'axios-retry';
 import MD5 from 'crypto-js/md5';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import WebSocket from 'ws';
 import { Logger, ILogObj } from 'tslog';
+
+// Configure retry capabilities
+axiosRetry(axios, {
+    retries: 3,
+    retryDelay: () => 100,
+    shouldResetTimeout: true,
+    retryCondition: (error) => {
+        return axiosRetry.isNetworkOrIdempotentRequestError(error) || error.code === "ECONNABORTED";
+    },
+});
 
 type DreoAuth = {
   // Data object returned from the Authenticate call
@@ -88,6 +99,16 @@ export type DreoCommands = {
 // Typescript sleep
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+// API details
+const DREO_API_CONFIG = {
+    ua: 'dreo/2.5.12 (sdk_gphone64_arm64;android 13;Scale/2.625)',
+    lang: 'en',
+    content_type: 'application/json; charset=UTF-8',
+    accept_encoding: 'gzip',
+    user_agent: 'okhttp/4.9.1',
+    timeout: 4
+}
+
 // Follows same request structure as the mobile app
 export class DreoAPI {
   private config: DreoConfig;
@@ -144,12 +165,13 @@ export class DreoAPI {
         'timestamp': Date.now(),
       },
       headers: {
-        'ua': 'dreo/2.5.12 (sdk_gphone64_arm64;android 13;Scale/2.625)',
-        'lang': 'en',
-        'content-type': 'application/json; charset=UTF-8',
-        'accept-encoding': 'gzip',
-        'user-agent': 'okhttp/4.9.1',
+        'ua': DREO_API_CONFIG.ua,
+        'lang': DREO_API_CONFIG.lang,
+        'content-type': DREO_API_CONFIG.content_type,
+        'accept-encoding': DREO_API_CONFIG.accept_encoding,
+        'user-agent': DREO_API_CONFIG.user_agent,
       },
+      timeout: DREO_API_CONFIG.timeout,
     })
     .then((response) => {
       const payload = response.data;
@@ -227,11 +249,12 @@ export class DreoAPI {
       },
       headers: {
         'authorization': `Bearer ${this.auth?.access_token}`,
-        'ua': 'dreo/2.5.12 (sdk_gphone64_arm64;android 13;Scale/2.625)',
-        'lang': 'en',
-        'accept-encoding': 'gzip',
-        'user-agent': 'okhttp/4.9.1',
+        'ua': DREO_API_CONFIG.ua,
+        'lang': DREO_API_CONFIG.lang,
+        'accept-encoding': DREO_API_CONFIG.accept_encoding,
+        'user-agent': DREO_API_CONFIG.user_agent,
       },
+      timeout: DREO_API_CONFIG.timeout,
     })
     // Catch and log errors
     .then((response) => {
@@ -275,11 +298,12 @@ export class DreoAPI {
       },
       headers: {
         'authorization': 'Bearer ' + this.auth?.access_token,
-        'ua': 'dreo/2.5.12 (sdk_gphone64_arm64;android 13;Scale/2.625)',
-        'lang': 'en',
-        'accept-encoding': 'gzip',
-        'user-agent': 'okhttp/4.9.1',
+        'ua': DREO_API_CONFIG.ua,
+        'lang': DREO_API_CONFIG.lang,
+        'accept-encoding': DREO_API_CONFIG.accept_encoding,
+        'user-agent': DREO_API_CONFIG.user_agent,
       },
+      timeout: DREO_API_CONFIG.timeout,
     })
     .then((response) => {
       const payload = response.data;

--- a/src/DreoAPI.ts
+++ b/src/DreoAPI.ts
@@ -106,7 +106,7 @@ const DREO_API_CONFIG = {
     content_type: 'application/json; charset=UTF-8',
     accept_encoding: 'gzip',
     user_agent: 'okhttp/4.9.1',
-    timeout: 4
+    timeout: 4000
 }
 
 // Follows same request structure as the mobile app


### PR DESCRIPTION
This PR fixes https://github.com/edabe/dreo-headwind/issues/1

#### Running the app as a _systemd_ service
Linux _systemd_ services can be restarted automatically in the event of a crash. 
Modify the README instructions to set up the app as a _systemd_ service that starts at boot.

#### Retrying DREO APIs
Configure `axios` with a 4 seconds timeout to avoid connection issues with the server. Also integrate with `axios-retry` to automatically retry idempotent API calls that fail due to network issues or due to "connection aborted".