### PR TITLE
feat(hr): Major changes to the heart rate logic

### DIFF
--- a/src/HeartRateMode.ts
+++ b/src/HeartRateMode.ts
@@ -41,7 +41,7 @@ export default class HeartRateMode {
     private hrZone: number[][];
     private hrHistory: number[]; 
     private currentProfile: DreoProfileType;
-    private currentSpeed: number;
+    private currentSpeed: number = 0;
     private timeoutId: NodeJS.Timeout;
     private index: number = 0;
     private isBusy: boolean = false;
@@ -75,7 +75,7 @@ export default class HeartRateMode {
 
     private async applyProfile(profileType: DreoProfileType, speed: number): Promise<void> {
         // Only apply profile if there is a diffrence from the current setting
-        if (this.currentProfile !== profileType && this.currentSpeed !== speed) {
+        if (this.currentProfile !== profileType || this.currentSpeed !== speed) {
             await DreoProfiles[profileType].apply(this.dreoSerialNumber, this.dreo);
             await this.dreo.airCirculatorSpeed(this.dreoSerialNumber, speed);
             this.currentProfile = profileType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,10 @@ import { SensorState } from 'incyclist-ant-plus/lib/sensors/base-sensor';
 import HeartRateMode from './HeartRateMode';
 
 // Initialize logger
-const logger = new Logger<ILogObj>({ name: 'dreo-headwind-logger' });
+const logger = new Logger<ILogObj>({ 
+    name: 'dreo-headwind-logger',
+    minLevel: 3
+});
 
 // Load configuration file
 nconf.file({ file: `${process.cwd()}/config/config.json` }).argv().env();
@@ -74,10 +77,10 @@ async function setupSensors(channel: Channel): Promise<void> {
 }
 
 // Handle the sensor messages
-function onDetected(profile: string): void {
+function onDetected(profile: string, deviceId: number): void {
     switch(profile) {
         case 'HR':
-            heartRateMode?.onDetectedHandler();
+            heartRateMode?.onDetectedHandler(deviceId);
             break;
     }
 }


### PR DESCRIPTION
This PR implements a number of changes to improve how the heart rate is monitored and used to control the different fan profiles:

#### Modify the heart rate logic
Define heart rate ranges based on the heart rate zones, resting heart rate and max heart rate according to the Karvonen method. Utility function `getHeartRateZones()` function implements the logic, converting the heart rate zones (percentage of HR) to an array of BPM ranges.

This resolves issue #3 

#### Modify fan profile / speed based on HR ranges
Revamp `applyProfile()` changing the fan behavior based on the current heart rate average, including deactivating the fan when the average is too low. 

This will allow fugure improvements to how the fan will respond to cooling down after long sustained efforts

#### Bug: `applyProfile` ignore changes in fan speed
Fix a small bug in which the `applyProfile` function will not process changes in the fan speed.

#### Modify heart rate history logic
The heart rate history (`hrHistory`) is updated based on the ANT HR profile's _Heart Beat Count_ property, which rolls over after 255 counts so the `hrHistory` should be sized accordingly to align with the rollover.

This change will allow future improvements to how the fan will respond to cooling down after long sustained efforts.

#### Modify the `onDetected()` callback
Modifies the `onDetected()` ANT callback to pass the device ID, allowing callback implementations to support multiple sensors. This is currently used for debugging purposes only.

