### PR TITLE
refactor(profile): Redesign the say profiles send command to fan

### DIFF
--- a/src/DreoAPI.ts
+++ b/src/DreoAPI.ts
@@ -220,7 +220,7 @@ export class DreoAPI {
     this.webSocketTimer = setInterval(() => this.webSocket?.send('2'), 15000);
   }
 
-  protected async sendCommand(serialNumber: string, parameters: object, wait: number): Promise<void> {
+  public async sendCommand(serialNumber: string, parameters: object, wait: number): Promise<void> {
     if (!this.webSocket) await this.startWebSocket();
     const message = JSON.stringify({
       'devicesn': serialNumber,

--- a/src/DreoProfile.ts
+++ b/src/DreoProfile.ts
@@ -3,18 +3,18 @@
  * A profile is a set of oscilating configurations to be
  * applied to the air circulator.
  */
-import { AirCirculatorOscillation, DreoAPI } from './DreoAPI';
+import { DreoAPI } from './DreoAPI';
 
 // This is the cruise parameters used in this context
 // Horizontal -15 to 15
 // Vertical 15 to 65
-const CRUISE_HORIZONTAL: [number, number] = [0, 30];
-const CRUISE_VERTICAL: [number, number] = [30, 30];
+// Cruise horizongal [0, 30]
+// Cruise vertical [30, 30]
 
 export abstract class DreoProfile {
-    name: string;
+    protected name: string;
     // All implementations must be async
-    abstract apply(dreoSerialNumber: string, dreoApi: DreoAPI): Promise<void>;
+    abstract apply(dreoSerialNumber: string, dreoApi: DreoAPI, fanSpeed: number): Promise<void>;
     toString(): string {
         return this?.name;
     }
@@ -22,54 +22,91 @@ export abstract class DreoProfile {
 
 class OscillateHorizontalProfile extends DreoProfile {
     name = 'OSCILATE_HORIZONTAL';
-    async apply(serialNumber: string, dreoApi: DreoAPI) {
-        await dreoApi.airCirculatorPowerOn(serialNumber, true);
-        await dreoApi.airCirculatorPosition(serialNumber, [0, 30]);
-        await dreoApi.airCirculatorCruise(serialNumber, CRUISE_HORIZONTAL, CRUISE_VERTICAL);
-        await dreoApi.airCirculatorOscillate(serialNumber, AirCirculatorOscillation.HORIZONTAL);
+    async apply(serialNumber: string, dreoApi: DreoAPI, fanSpeed: number) {
+        // Create a command template for this profile
+        const template = {
+            power: true, // Turn on fan
+            fixedconf: '30,0', // Set position (equivalent to position [0,30])
+            cruiseconf: '45,15,15,-15', // Set cruise mode (equivalent to CRUISE_HORIZONTAL, CRUISE_VERTICAL)
+            oscmode: 1, // Set oscillation (equivalnt to AirCirculatorOscillation.HORIZONTAL)
+            windlevel: fanSpeed
+        };
+        await dreoApi.sendCommand(serialNumber, template, 1000);
     }
 }
 
 class OscillateVerticalProfile extends DreoProfile {
     name = 'OSCILATE_VERTICAL';
-    async apply(serialNumber: string, dreoApi: DreoAPI) {
-        await dreoApi.airCirculatorPowerOn(serialNumber, true);
-        await dreoApi.airCirculatorPosition(serialNumber, [0, 30]);
-        await dreoApi.airCirculatorCruise(serialNumber, CRUISE_HORIZONTAL, CRUISE_VERTICAL);
-        await dreoApi.airCirculatorOscillate(serialNumber, AirCirculatorOscillation.VERTICAL);
+    async apply(serialNumber: string, dreoApi: DreoAPI, fanSpeed: number) {
+        // Create a command template for this profile
+        const template = {
+            power: true, // Turn on fan
+            fixedconf: '30,0', // Set position (equivalent to position [0,30])
+            cruiseconf: '45,15,15,-15', // Set cruise mode (equivalent to CRUISE_HORIZONTAL, CRUISE_VERTICAL)
+            oscmode: 2, // Set oscillation (equivalnt to AirCirculatorOscillation.VERTICAL)
+            windlevel: fanSpeed
+        };
+        await dreoApi.sendCommand(serialNumber, template, 1000);
     }
 }
 
 class OscillateHorizontalVerticalProfile extends DreoProfile {
     name = 'OSCILATE_HORIZONTAL_VERTICAL';
-    async apply(serialNumber: string, dreoApi: DreoAPI) {
-        await dreoApi.airCirculatorPowerOn(serialNumber, true);
-        await dreoApi.airCirculatorCruise(serialNumber, CRUISE_HORIZONTAL, CRUISE_VERTICAL);
-        await dreoApi.airCirculatorOscillate(serialNumber, AirCirculatorOscillation.HORIZONTAL_VERTICAL);
+    async apply(serialNumber: string, dreoApi: DreoAPI, fanSpeed: number) {
+        // Create a command template for this profile
+        const template = {
+            power: true, // Turn on fan
+            fixedconf: '30,0', // Set position (equivalent to position [0,30])
+            cruiseconf: '45,15,15,-15', // Set cruise mode (equivalent to CRUISE_HORIZONTAL, CRUISE_VERTICAL)
+            oscmode: 3, // Set oscillation (equivalnt to AirCirculatorOscillation.HORIZONTAL_VERTICAL)
+            windlevel: fanSpeed
+        };
+        await dreoApi.sendCommand(serialNumber, template, 1000);
     }
 }
 
 class Center45Degrees extends DreoProfile {
     name = 'CENTER_45_DEGREE';
-    async apply(serialNumber: string, dreoApi: DreoAPI) {
-        await dreoApi.airCirculatorPowerOn(serialNumber, true);
-        await dreoApi.airCirculatorPosition(serialNumber, [0, 45]);
+    async apply(serialNumber: string, dreoApi: DreoAPI, fanSpeed: number) {
+        // Create a command template for this profile
+        const template = {
+            power: true, // Turn on fan
+            fixedconf: '45,0', // Set position (equivalent to position [0,45])
+            cruiseconf: '45,15,15,-15', // Set cruise mode (equivalent to CRUISE_HORIZONTAL, CRUISE_VERTICAL)
+            oscmode: 0, // Set oscillation (equivalnt to AirCirculatorOscillation.NONE)
+            windlevel: fanSpeed
+        };
+        await dreoApi.sendCommand(serialNumber, template, 1000);
     }
 }
 
 class Center30Degrees extends DreoProfile {
     name = 'CENTER_30_DEGREE';
-    async apply(serialNumber: string, dreoApi: DreoAPI) {
-        await dreoApi.airCirculatorPowerOn(serialNumber, true);
-        await dreoApi.airCirculatorPosition(serialNumber, [0, 30]);
+    async apply(serialNumber: string, dreoApi: DreoAPI, fanSpeed: number) {
+        // Create a command template for this profile
+        const template = {
+            power: true, // Turn on fan
+            fixedconf: '30,0', // Set position (equivalent to position [0,30])
+            cruiseconf: '45,15,15,-15', // Set cruise mode (equivalent to CRUISE_HORIZONTAL, CRUISE_VERTICAL)
+            oscmode: 0, // Set oscillation (equivalnt to AirCirculatorOscillation.NONE)
+            windlevel: fanSpeed
+        };
+        await dreoApi.sendCommand(serialNumber, template, 1000);
     }
 }
 
 class Center0Degrees extends DreoProfile {
     name = 'CENTER_0_DEGREE';
-    async apply(serialNumber: string, dreoApi: DreoAPI) {
-        await dreoApi.airCirculatorPowerOn(serialNumber, true);
-        await dreoApi.airCirculatorPosition(serialNumber, [0, 0]);
+    async apply(serialNumber: string, dreoApi: DreoAPI, fanSpeed: number) {
+        // Create a command template for this profile
+        const template = {
+            power: true, // Turn on fan
+            fixedconf: '0,0', // Set position (equivalent to position [0,0])
+            cruiseconf: '45,15,15,-15', // Set cruise mode (equivalent to CRUISE_HORIZONTAL, CRUISE_VERTICAL)
+            oscmode: 0, // Set oscillation (equivalnt to AirCirculatorOscillation.NONE)
+            windlevel: fanSpeed
+        };
+        await dreoApi.sendCommand(serialNumber, template, 1000);
     }
 }
 

--- a/src/HeartRateMode.ts
+++ b/src/HeartRateMode.ts
@@ -180,8 +180,7 @@ export default class HeartRateMode {
         if (this.hrProfile !== fanProfile || currentSpeed !== fanSpeed) {
             this.hrProfile = fanProfile;
             this.logger.info(`Adjusting profile: ${this.hrProfile} with fan speed ${fanSpeed}, HR ${this.hrSmoothed} BMP and ${temperature}F`);
-            await DreoProfiles[fanProfile].apply(this.dreoSerialNumber, this.dreo); // 'apply' will turn the fan on if needed
-            await this.dreo.airCirculatorSpeed(this.dreoSerialNumber, fanSpeed);
+            await DreoProfiles[fanProfile].apply(this.dreoSerialNumber, this.dreo, fanSpeed); // 'apply' will turn the fan on if needed
         }
         this.isAdjustDreoProfileBusy = false;
     }

--- a/tests/HeartRateModePrivate.test.ts
+++ b/tests/HeartRateModePrivate.test.ts
@@ -112,7 +112,7 @@ describe('HeartRateMode', () => {
 
         describe('Checks that adjustDreoProfile works as expected', () => {
             let spyDreoGetState: any;
-            let spyDreoAirCirculatorSpeed: any;
+            let spyDreoSendCommand: any;
             let spyGetFanSpeed: any;
             let spyAdjustSpeedForTemperature: any;
             let spyProfileCenter0Apply: any;
@@ -123,7 +123,7 @@ describe('HeartRateMode', () => {
 
             beforeEach(() => {
                 spyDreoGetState = jest.spyOn(hrm.dreo, 'getState');
-                spyDreoAirCirculatorSpeed = jest.spyOn(hrm.dreo, 'airCirculatorSpeed');
+                spyDreoSendCommand = jest.spyOn(hrm.dreo, 'sendCommand');
                 spyGetFanSpeed = jest.spyOn(hrm, 'getFanSpeed');
                 spyAdjustSpeedForTemperature = jest.spyOn(hrm, 'adjustSpeedForTemperature');
                 spyProfileCenter0Apply = jest.spyOn(DreoProfiles[DreoProfileType.CENTER_0], 'apply');
@@ -135,7 +135,7 @@ describe('HeartRateMode', () => {
 
             afterEach(() => {
                 spyDreoGetState.mockClear();
-                spyDreoAirCirculatorSpeed.mockClear();
+                spyDreoSendCommand.mockClear();
                 spyGetFanSpeed.mockClear();
                 spyAdjustSpeedForTemperature.mockClear();
                 spyProfileCenter0Apply.mockClear();
@@ -211,7 +211,7 @@ describe('HeartRateMode', () => {
                 expect(spyProfileCenter30Apply).toHaveBeenCalledTimes(2);
                 expect(spyProfileCenter45Apply).toHaveBeenCalledTimes(4);
                 expect(spyProfileVerticalApply).toHaveBeenCalledTimes(0);
-                expect(spyDreoAirCirculatorSpeed).toHaveBeenCalledTimes(7);
+                expect(spyDreoSendCommand).toHaveBeenCalledTimes(7);
             });
 
             it('Checks oscillation scenario', async () => {
@@ -233,7 +233,7 @@ describe('HeartRateMode', () => {
                 expect(spyProfileCenter30Apply).toHaveBeenCalledTimes(0);
                 expect(spyProfileCenter45Apply).toHaveBeenCalledTimes(0);
                 expect(spyProfileVerticalApply).toHaveBeenCalledTimes(1);
-                expect(spyDreoAirCirculatorSpeed).toHaveBeenCalledTimes(2);
+                expect(spyDreoSendCommand).toHaveBeenCalledTimes(2);
             });
 
             /**


### PR DESCRIPTION
Fix issue https://github.com/edabe/dreo-headwind/issues/16

The profile `apply()` function now calls the Dreo API `sendCommand()` function directly, combining all instructions into one command.

This greatly improves the time it to update a fan profile at the expense of some small flexibility: If the fan is operated outside of the scope of the app, it might end up out of sync (example: pointing to the side instead of the center)